### PR TITLE
fix:CVE-2022-3341

### DIFF
--- a/debian/patches/0001-fix-CVE-2022-3341.patch
+++ b/debian/patches/0001-fix-CVE-2022-3341.patch
@@ -1,0 +1,57 @@
+From 563cc94e2017b2e596d40fe0724ac2e4ff33343b Mon Sep 17 00:00:00 2001
+From: Stwsyburg <suyuanwang@hust.edu.cn>
+Date: Fri, 14 Apr 2023 03:53:39 +0800
+Subject: [PATCH] fix:CVE-2022-3341
+
+---
+ libavformat/nutdec.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/libavformat/nutdec.c b/libavformat/nutdec.c
+index e86d822..d2fe5eb 100644
+--- a/libavformat/nutdec.c
++++ b/libavformat/nutdec.c
+@@ -351,8 +351,12 @@ static int decode_main_header(NUTContext *nut)
+         ret = AVERROR(ENOMEM);
+         goto fail;
+     }
+-    for (i = 0; i < stream_count; i++)
+-        avformat_new_stream(s, NULL);
++    for (i = 0; i < stream_count; i++) {
++        if (!avformat_new_stream(s, NULL)) {
++            ret = AVERROR(ENOMEM);
++            goto fail;
++        }
++    }
+ 
+     return 0;
+ fail:
+@@ -798,19 +802,23 @@ static int nut_read_header(AVFormatContext *s)
+     NUTContext *nut = s->priv_data;
+     AVIOContext *bc = s->pb;
+     int64_t pos;
+-    int initialized_stream_count;
++    int initialized_stream_count, ret;
+ 
+     nut->avf = s;
+ 
+     /* main header */
+     pos = 0;
++    ret = 0;
+     do {
++        if (ret == AVERROR(ENOMEM))
++            return ret;
++
+         pos = find_startcode(bc, MAIN_STARTCODE, pos) + 1;
+         if (pos < 0 + 1) {
+             av_log(s, AV_LOG_ERROR, "No main startcode found.\n");
+             goto fail;
+         }
+-    } while (decode_main_header(nut) < 0);
++    } while ((ret = decode_main_header(nut)) < 0);
+ 
+     /* stream headers */
+     pos = 0;
+-- 
+2.25.1
+


### PR DESCRIPTION
libavformat/nutdec.c文件的decode_main_header（）函数中发现了空指针引用问题。出现该问题是因为该函数缺少对avformat_new_stream（）的返回值的检查，并触发了空指针引用错误，导致应用程序崩溃。