### PR TITLE
feat: add libmbedtls-dev build dependency for sw64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ffmpeg (7:6.1.1-2deepin3) unstable; urgency=medium
+
+  * Add libmbedtls-dev build dependency for sw64
+
+ -- renbin <renbin@uniontech.com>  Thu, 03 Apr 2025 09:26:59 +0800
+
 ffmpeg (7:6.1.1-2deepin2) unstable; urgency=medium
 
   * Added AVS format support.

--- a/debian/control
+++ b/debian/control
@@ -205,7 +205,9 @@ Build-Depends:
 # --enable-libdavs2
  libdavs2-dev,
 # --enable-libxavs2
- libxavs2-dev
+ libxavs2-dev,
+# required on sw64
+ libmbedtls-dev [sw64]
 
 Package: ffmpeg
 Architecture: any


### PR DESCRIPTION
The sw64 architecture requires libmbedtls-dev for building ffmpeg. Using architecture qualifier to ensure this dependency is only added for sw64.

Log: add libmbedtls-dev build dependency for sw64.