### PR TITLE
fix(swscale): apply patch for CVE-2025-63757

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ffmpeg (7:6.1.1-2deepin7) unstable; urgency=medium
+
+  * chore: Update version to 7:6.1.1-2deepin7
+  * fix: [566e903] {swscale,output}: Fix unsigned cast position in yuv2*
+  * fix: [0c6b7f9] {swscale,output}: 	swscale/output: Fix integer overflow in yuv2ya16_X_c_template()
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Mon, 19 Jan 2026 14:31:35 +0800
+
 ffmpeg (7:6.1.1-2deepin6) unstable; urgency=medium
 
   * Apply patch from upstream to fix FTBFS:

--- a/debian/patches/0003-swscale-output-cve-2025-63757.patch
+++ b/debian/patches/0003-swscale-output-cve-2025-63757.patch
@@ -1,0 +1,251 @@
+Index: deepin-ffmpeg/libswscale/output.c
+===================================================================
+--- deepin-ffmpeg.orig/libswscale/output.c
++++ deepin-ffmpeg/libswscale/output.c
+@@ -440,8 +440,8 @@ static void yuv2nv12cX_c(enum AVPixelFor
+             int v = chrDither[(i + 3) & 7] << 12;
+             int j;
+             for (j=0; j<chrFilterSize; j++) {
+-                u += chrUSrc[j][i] * chrFilter[j];
+-                v += chrVSrc[j][i] * chrFilter[j];
++                u += chrUSrc[j][i] * (unsigned)chrFilter[j];
++                v += chrVSrc[j][i] * (unsigned)chrFilter[j];
+             }
+ 
+             dest[2*i]= av_clip_uint8(u>>19);
+@@ -453,8 +453,8 @@ static void yuv2nv12cX_c(enum AVPixelFor
+             int v = chrDither[(i + 3) & 7] << 12;
+             int j;
+             for (j=0; j<chrFilterSize; j++) {
+-                u += chrUSrc[j][i] * chrFilter[j];
+-                v += chrVSrc[j][i] * chrFilter[j];
++                u += chrUSrc[j][i] * (unsigned)chrFilter[j];
++                v += chrVSrc[j][i] * (unsigned)chrFilter[j];
+             }
+ 
+             dest[2*i]= av_clip_uint8(v>>19);
+@@ -517,8 +517,8 @@ static void yuv2p01xcX_c(int big_endian,
+         int v = 1 << (shift - 1);
+ 
+         for (j = 0; j < chrFilterSize; j++) {
+-            u += chrUSrc[j][i] * chrFilter[j];
+-            v += chrVSrc[j][i] * chrFilter[j];
++            u += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            v += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+ 
+         output_pixel(&dest[2*i]  , u);
+@@ -615,8 +615,8 @@ yuv2mono_X_c_template(SwsContext *c, con
+         int Y2 = 1 << 18;
+ 
+         for (j = 0; j < lumFilterSize; j++) {
+-            Y1 += lumSrc[j][i]   * lumFilter[j];
+-            Y2 += lumSrc[j][i+1] * lumFilter[j];
++            Y1 += lumSrc[j][i]   * (unsigned)lumFilter[j];
++            Y2 += lumSrc[j][i+1] * (unsigned)lumFilter[j];
+         }
+         Y1 >>= 19;
+         Y2 >>= 19;
+@@ -832,12 +832,12 @@ yuv2422_X_c_template(SwsContext *c, cons
+         int V  = 1 << 18;
+ 
+         for (j = 0; j < lumFilterSize; j++) {
+-            Y1 += lumSrc[j][i * 2]     * lumFilter[j];
+-            Y2 += lumSrc[j][i * 2 + 1] * lumFilter[j];
++            Y1 += lumSrc[j][i * 2]     * (unsigned)lumFilter[j];
++            Y2 += lumSrc[j][i * 2 + 1] * (unsigned)lumFilter[j];
+         }
+         for (j = 0; j < chrFilterSize; j++) {
+-            U += chrUSrc[j][i] * chrFilter[j];
+-            V += chrVSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+         Y1 >>= 19;
+         Y2 >>= 19;
+@@ -964,7 +964,7 @@ yuv2ya16_X_c_template(SwsContext *c, con
+         int A = 0xffff;
+ 
+         for (j = 0; j < lumFilterSize; j++)
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+ 
+         Y >>= 15;
+         Y += (1<<3) + 0x8000;
+@@ -973,7 +973,7 @@ yuv2ya16_X_c_template(SwsContext *c, con
+         if (hasAlpha) {
+             A = -0x40000000 + (1<<14);
+             for (j = 0; j < lumFilterSize; j++)
+-                A += alpSrc[j][i] * lumFilter[j];
++                A += alpSrc[j][i] * (unsigned)lumFilter[j];
+ 
+             A >>= 15;
+             A += 0x8000;
+@@ -1727,12 +1727,12 @@ yuv2rgb_X_c_template(SwsContext *c, cons
+         const void *r, *g, *b;
+ 
+         for (j = 0; j < lumFilterSize; j++) {
+-            Y1 += lumSrc[j][i * 2]     * lumFilter[j];
+-            Y2 += lumSrc[j][i * 2 + 1] * lumFilter[j];
++            Y1 += lumSrc[j][i * 2]     * (unsigned)lumFilter[j];
++            Y2 += lumSrc[j][i * 2 + 1] * (unsigned)lumFilter[j];
+         }
+         for (j = 0; j < chrFilterSize; j++) {
+-            U += chrUSrc[j][i] * chrFilter[j];
+-            V += chrVSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+         Y1 >>= 19;
+         Y2 >>= 19;
+@@ -1742,8 +1742,8 @@ yuv2rgb_X_c_template(SwsContext *c, cons
+             A1 = 1 << 18;
+             A2 = 1 << 18;
+             for (j = 0; j < lumFilterSize; j++) {
+-                A1 += alpSrc[j][i * 2    ] * lumFilter[j];
+-                A2 += alpSrc[j][i * 2 + 1] * lumFilter[j];
++                A1 += alpSrc[j][i * 2    ] * (unsigned)lumFilter[j];
++                A2 += alpSrc[j][i * 2 + 1] * (unsigned)lumFilter[j];
+             }
+             A1 >>= 19;
+             A2 >>= 19;
+@@ -2089,11 +2089,11 @@ yuv2rgb_full_X_c_template(SwsContext *c,
+         int V = (1<<9)-(128 << 19);
+ 
+         for (j = 0; j < lumFilterSize; j++) {
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+         }
+         for (j = 0; j < chrFilterSize; j++) {
+-            U += chrUSrc[j][i] * chrFilter[j];
+-            V += chrVSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+         Y >>= 10;
+         U >>= 10;
+@@ -2101,7 +2101,7 @@ yuv2rgb_full_X_c_template(SwsContext *c,
+         if (hasAlpha) {
+             A = 1 << 18;
+             for (j = 0; j < lumFilterSize; j++) {
+-                A += alpSrc[j][i] * lumFilter[j];
++                A += alpSrc[j][i] * (unsigned)lumFilter[j];
+             }
+             A >>= 19;
+             if (A & 0x100)
+@@ -2264,11 +2264,11 @@ yuv2gbrp_full_X_c(SwsContext *c, const i
+         int R, G, B;
+ 
+         for (j = 0; j < lumFilterSize; j++)
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+ 
+         for (j = 0; j < chrFilterSize; j++) {
+-            U += chrUSrc[j][i] * chrFilter[j];
+-            V += chrVSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+ 
+         Y >>= 10;
+@@ -2279,7 +2279,7 @@ yuv2gbrp_full_X_c(SwsContext *c, const i
+             A = 1 << 18;
+ 
+             for (j = 0; j < lumFilterSize; j++)
+-                A += alpSrc[j][i] * lumFilter[j];
++                A += alpSrc[j][i] * (unsigned)lumFilter[j];
+ 
+             if (A & 0xF8000000)
+                 A =  av_clip_uintp2(A, 27);
+@@ -2543,7 +2543,7 @@ yuv2ya8_X_c(SwsContext *c, const int16_t
+         int Y = 1 << 18, A = 1 << 18;
+ 
+         for (j = 0; j < lumFilterSize; j++)
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+ 
+         Y >>= 19;
+         if (Y  & 0x100)
+@@ -2551,7 +2551,7 @@ yuv2ya8_X_c(SwsContext *c, const int16_t
+ 
+         if (hasAlpha) {
+             for (j = 0; j < lumFilterSize; j++)
+-                A += alpSrc[j][i] * lumFilter[j];
++                A += alpSrc[j][i] * (unsigned)lumFilter[j];
+ 
+             A >>= 19;
+ 
+@@ -2626,11 +2626,11 @@ yuv2xv30le_X_c(SwsContext *c, const int1
+         int j;
+ 
+         for (j = 0; j < lumFilterSize; j++)
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+ 
+         for (j = 0; j < chrFilterSize; j++) {
+-            U += chrUSrc[j][i] * chrFilter[j];
+-            V += chrVSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+ 
+         Y = av_clip_uintp2(Y >> 17, 10);
+@@ -2654,11 +2654,11 @@ yuv2xv36le_X_c(SwsContext *c, const int1
+         int j;
+ 
+         for (j = 0; j < lumFilterSize; j++)
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+ 
+         for (j = 0; j < chrFilterSize; j++) {
+-            U += chrUSrc[j][i] * chrFilter[j];
+-            V += chrVSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+         }
+ 
+         AV_WL16(dest + 8 * i + 2, av_clip_uintp2(Y >> 15, 12) << 4);
+@@ -2684,13 +2684,13 @@ yuv2vuyX_X_c(SwsContext *c, const int16_
+         int V = 1 << 18, A = 255;
+ 
+         for (j = 0; j < lumFilterSize; j++)
+-            Y += lumSrc[j][i] * lumFilter[j];
++            Y += lumSrc[j][i] * (unsigned)lumFilter[j];
+ 
+         for (j = 0; j < chrFilterSize; j++)
+-            U += chrUSrc[j][i] * chrFilter[j];
++            U += chrUSrc[j][i] * (unsigned)chrFilter[j];
+ 
+         for (j = 0; j < chrFilterSize; j++)
+-            V += chrVSrc[j][i] * chrFilter[j];
++            V += chrVSrc[j][i] * (unsigned)chrFilter[j];
+ 
+         Y >>= 19;
+         U >>= 19;
+@@ -2707,7 +2707,7 @@ yuv2vuyX_X_c(SwsContext *c, const int16_
+             A = 1 << 18;
+ 
+             for (j = 0; j < lumFilterSize; j++)
+-                A += alpSrc[j][i] * lumFilter[j];
++                A += alpSrc[j][i] * (unsigned)lumFilter[j];
+ 
+             A >>= 19;
+ 
+@@ -2766,13 +2766,13 @@ yuv2vuyx_X_c(SwsContext *c, const int16_
+             int U  = 1 << (shift - 1), V  = 1 << (shift - 1);           \
+                                                                         \
+             for (j = 0; j < lumFilterSize; j++) {                       \
+-                Y1 += lumSrc[j][i * 2]     * lumFilter[j];              \
+-                Y2 += lumSrc[j][i * 2 + 1] * lumFilter[j];              \
++                Y1 += lumSrc[j][i * 2]     * (unsigned)lumFilter[j];    \
++                Y2 += lumSrc[j][i * 2 + 1] * (unsigned)lumFilter[j];    \
+             }                                                           \
+                                                                         \
+             for (j = 0; j < chrFilterSize; j++) {                       \
+-                U += chrUSrc[j][i] * chrFilter[j];                      \
+-                V += chrVSrc[j][i] * chrFilter[j];                      \
++                U += chrUSrc[j][i] * (unsigned)chrFilter[j];            \
++                V += chrVSrc[j][i] * (unsigned)chrFilter[j];            \
+             }                                                           \
+                                                                         \
+             output_pixel(dest + 8 * i + 0, Y1, bits);                   \

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-configure-fix-compilation-with-glslang-14.patch
 0002-avcodec-tests-rename-the-bundled-Mesa-AV1-vulkan-vid.patch
+0003-swscale-output-cve-2025-63757.patch


### PR DESCRIPTION
Add security patch to address CVE-2025-63757 vulnerability in swscale module.

upstreams fix commits:
  * fix: [566e903] {swscale,output}: Fix unsigned cast position in yuv2*
  * fix: [0c6b7f9] {swscale,output}: swscale/output: Fix integer overflow in yuv2ya16_X_c_template()

links:
  * https://security-tracker.debian.org/tracker/CVE-2025-63757
  * https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/20698