### PR TITLE
fix(avcodec): apply patch for CVE-2025-9951

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ffmpeg (7:6.1.1-2deepin8) unstable; urgency=medium
+
+  * chore: Update version to 7:6.1.1-2deepin8
+  * fix(avcodec): apply patch for CVE-2025-9951
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Mon, 19 Jan 2026 17:26:38 +0800
+
 ffmpeg (7:6.1.1-2deepin7) unstable; urgency=medium
 
   * chore: Update version to 7:6.1.1-2deepin7

--- a/debian/patches/0004-avcodec-jpeg2000dec-cve-2025-9951.patch
+++ b/debian/patches/0004-avcodec-jpeg2000dec-cve-2025-9951.patch
@@ -1,0 +1,59 @@
+Index: deepin-ffmpeg/libavcodec/jpeg2000dec.c
+===================================================================
+--- deepin-ffmpeg.orig/libavcodec/jpeg2000dec.c
++++ deepin-ffmpeg/libavcodec/jpeg2000dec.c
+@@ -261,6 +261,25 @@ static int get_siz(Jpeg2000DecoderContex
+         return AVERROR_INVALIDDATA;
+     }
+ 
++    for (i = 0; i < s->ncomponents; i++) {
++        if (s->cdef[i] < 0) {
++            for (i = 0; i < s->ncomponents; i++) {
++                s->cdef[i] = i + 1;
++            }
++            if ((s->ncomponents & 1) == 0)
++                s->cdef[s->ncomponents-1] = 0;
++        }
++    }
++    // after here we no longer have to consider negative cdef
++
++    int cdef_used = 0;
++    for (i = 0; i < s->ncomponents; i++)
++        cdef_used |= 1<<s->cdef[i];
++
++    // Check that the channels we have are what we expect for the number of components
++    if (cdef_used != ((int[]){0,2,3,14,15})[s->ncomponents])
++        return AVERROR_INVALIDDATA;
++
+     for (i = 0; i < s->ncomponents; i++) { // Ssiz_i XRsiz_i, YRsiz_i
+         uint8_t x    = bytestream2_get_byteu(&s->g);
+         s->cbps[i]   = (x & 0x7f) + 1;
+@@ -273,7 +292,9 @@ static int get_siz(Jpeg2000DecoderContex
+             av_log(s->avctx, AV_LOG_ERROR, "Invalid sample separation %d/%d\n", s->cdx[i], s->cdy[i]);
+             return AVERROR_INVALIDDATA;
+         }
+-        log2_chroma_wh |= s->cdy[i] >> 1 << i * 4 | s->cdx[i] >> 1 << i * 4 + 2;
++        int i_remapped = s->cdef[i] ? s->cdef[i]-1 : (s->ncomponents-1);
++
++        log2_chroma_wh |= s->cdy[i] >> 1 << i_remapped * 4 | s->cdx[i] >> 1 << i_remapped * 4 + 2;
+     }
+ 
+     s->numXtiles = ff_jpeg2000_ceildiv(s->width  - s->tile_offset_x, s->tile_width);
+@@ -2505,17 +2526,6 @@ static int jpeg2000_decode_frame(AVCodec
+     if (ret = jpeg2000_read_bitstream_packets(s))
+         goto end;
+ 
+-    for (int x = 0; x < s->ncomponents; x++) {
+-        if (s->cdef[x] < 0) {
+-            for (x = 0; x < s->ncomponents; x++) {
+-                s->cdef[x] = x + 1;
+-            }
+-            if ((s->ncomponents & 1) == 0)
+-                s->cdef[s->ncomponents-1] = 0;
+-            break;
+-        }
+-    }
+-
+     avctx->execute2(avctx, jpeg2000_decode_tile, picture, NULL, s->numXtiles * s->numYtiles);
+ 
+     jpeg2000_dec_cleanup(s);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 0001-configure-fix-compilation-with-glslang-14.patch
 0002-avcodec-tests-rename-the-bundled-Mesa-AV1-vulkan-vid.patch
 0003-swscale-output-cve-2025-63757.patch
+0004-avcodec-jpeg2000dec-cve-2025-9951.patch


### PR DESCRIPTION
Add security patch to address CVE-2025-9951 vulnerability in swscale module.

upstreams fix commits:
  * fix: [01a292c7e3] {avcodec,jpeg2000dec}: implement cdef remapping during pixel format matching", 2025-08-05)
  * fix: [104d6846c1] {avcodec,jpeg2000dec}: move cdef default check into get_siz()", 2025-08-05)

links:
  * https://github.com/FFmpeg/FFmpeg/commit/01a292c7e3
  * https://github.com/FFmpeg/FFmpeg/commit/104d6846c1
  * https://security-tracker.debian.org/tracker/CVE-2025-9951