### PR TITLE
Fix CVE-2023-49501 CVE-2023-49528 CVE-2023-50009 CVE-2024-35365 CVE-2024-36615

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+ffmpeg (7:6.1.1-2deepin9) unstable; urgency=medium
+
+  * chore: Update version to 7:6.1.1-2deepin9
+  * fix: apply patches from upstream to fix multiple CVE vulnerabilities:
+    - CVE-2023-49501: avfilter/asrc_afirsrc: fix by one smaller allocation of buffer
+    - CVE-2023-49528: avfilter/af_dialoguenhance: fix overreads
+    - CVE-2023-50009: avfilter/edge_template: Fix small inputs with gaussian_blur()
+    - CVE-2024-35365: fftools/ffmpeg_mux_init: Fix double-free on error
+    - CVE-2024-36615: avcodec/vp9: Fix race when attaching side-data for show-existing frame
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Mon, 19 Jan 2026 17:26:38 +0800
+
 ffmpeg (7:6.1.1-2deepin8) unstable; urgency=medium
 
   * chore: Update version to 7:6.1.1-2deepin8

--- a/debian/patches/CVE-2023-49501.patch
+++ b/debian/patches/CVE-2023-49501.patch
@@ -1,0 +1,26 @@
+From 4adb93dff05dd947878c67784d98c9a4e13b57a7 Mon Sep 17 00:00:00 2001
+From: Paul B Mahol <onemda@gmail.com>
+Date: Thu, 23 Nov 2023 14:58:35 +0100
+Subject: [PATCH] avfilter/asrc_afirsrc: fix by one smaller allocation of
+ buffer
+
+Fixes: Ticket10686
+
+Signed-off-by: Paul B Mahol <onemda@gmail.com>
+---
+ libavfilter/asrc_afirsrc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavfilter/asrc_afirsrc.c b/libavfilter/asrc_afirsrc.c
+index e2359c159f41e..ea04c35759418 100644
+--- a/libavfilter/asrc_afirsrc.c
++++ b/libavfilter/asrc_afirsrc.c
+@@ -480,7 +480,7 @@ static av_cold int config_eq_output(AVFilterLink *outlink)
+         if (ret < 0)
+             return ret;
+
+-        s->magnitude = av_calloc(s->nb_magnitude, sizeof(*s->magnitude));
++        s->magnitude = av_calloc(s->nb_magnitude + 1, sizeof(*s->magnitude));
+         if (!s->magnitude)
+             return AVERROR(ENOMEM);
+         memcpy(s->magnitude, eq_presets[s->preset].gains, sizeof(*s->magnitude) * s->nb_magnitude);

--- a/debian/patches/CVE-2023-49528.patch
+++ b/debian/patches/CVE-2023-49528.patch
@@ -1,0 +1,53 @@
+From 2d9ed64859c9887d0504cd71dbd5b2c15e14251a Mon Sep 17 00:00:00 2001
+From: Paul B Mahol <onemda@gmail.com>
+Date: Sat, 25 Nov 2023 12:54:28 +0100
+Subject: [PATCH] avfilter/af_dialoguenhance: fix overreads
+
+Fixes: Ticket10691
+
+Signed-off-by: Paul B Mahol <onemda@gmail.com>
+---
+ libavfilter/af_dialoguenhance.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/libavfilter/af_dialoguenhance.c b/libavfilter/af_dialoguenhance.c
+index 1762ea7cde691..29c8ab10a720d 100644
+--- a/libavfilter/af_dialoguenhance.c
++++ b/libavfilter/af_dialoguenhance.c
+@@ -96,12 +96,12 @@ static int config_input(AVFilterLink *inlink)
+     if (!s->window)
+         return AVERROR(ENOMEM);
+
+-    s->in_frame       = ff_get_audio_buffer(inlink, s->fft_size * 4);
+-    s->center_frame   = ff_get_audio_buffer(inlink, s->fft_size * 4);
+-    s->out_dist_frame = ff_get_audio_buffer(inlink, s->fft_size * 4);
+-    s->windowed_frame = ff_get_audio_buffer(inlink, s->fft_size * 4);
+-    s->windowed_out   = ff_get_audio_buffer(inlink, s->fft_size * 4);
+-    s->windowed_prev  = ff_get_audio_buffer(inlink, s->fft_size * 4);
++    s->in_frame       = ff_get_audio_buffer(inlink, (s->fft_size + 2) * 2);
++    s->center_frame   = ff_get_audio_buffer(inlink, (s->fft_size + 2) * 2);
++    s->out_dist_frame = ff_get_audio_buffer(inlink, (s->fft_size + 2) * 2);
++    s->windowed_frame = ff_get_audio_buffer(inlink, (s->fft_size + 2) * 2);
++    s->windowed_out   = ff_get_audio_buffer(inlink, (s->fft_size + 2) * 2);
++    s->windowed_prev  = ff_get_audio_buffer(inlink, (s->fft_size + 2) * 2);
+     if (!s->in_frame || !s->windowed_out || !s->windowed_prev ||
+         !s->out_dist_frame || !s->windowed_frame || !s->center_frame)
+         return AVERROR(ENOMEM);
+@@ -250,6 +250,7 @@ static int de_stereo(AVFilterContext *ctx, AVFrame *out)
+     float *right_osamples  = (float *)out->extended_data[1];
+     float *center_osamples = (float *)out->extended_data[2];
+     const int offset = s->fft_size - s->overlap;
++    const int nb_samples = FFMIN(s->overlap, s->in->nb_samples);
+     float vad;
+
+     // shift in/out buffers
+@@ -258,8 +259,8 @@ static int de_stereo(AVFilterContext *ctx, AVFrame *out)
+     memmove(left_out, &left_out[s->overlap], offset * sizeof(float));
+     memmove(right_out, &right_out[s->overlap], offset * sizeof(float));
+
+-    memcpy(&left_in[offset], left_samples, s->overlap * sizeof(float));
+-    memcpy(&right_in[offset], right_samples, s->overlap * sizeof(float));
++    memcpy(&left_in[offset], left_samples, nb_samples * sizeof(float));
++    memcpy(&right_in[offset], right_samples, nb_samples * sizeof(float));
+     memset(&left_out[offset], 0, s->overlap * sizeof(float));
+     memset(&right_out[offset], 0, s->overlap * sizeof(float));

--- a/debian/patches/CVE-2023-50009.patch
+++ b/debian/patches/CVE-2023-50009.patch
@@ -1,0 +1,72 @@
+From c443658d26d2b8e19901f9507a890e0efca79056 Mon Sep 17 00:00:00 2001
+From: Michael Niedermayer <michael@niedermayer.cc>
+Date: Fri, 22 Dec 2023 11:54:24 +0100
+Subject: [PATCH] avfilter/edge_template: Fix small inputs with
+ gaussian_blur()
+
+Fixes: out of array access
+Fixes: Ticket10699
+Fixes: poc5ffmpeg
+
+Found-by: Zeng Yunxiang
+Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>
+---
+ libavfilter/edge_template.c | 29 +++++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/libavfilter/edge_template.c b/libavfilter/edge_template.c
+index 14635c25af0a9..ce45e579db59f 100644
+--- a/libavfilter/edge_template.c
++++ b/libavfilter/edge_template.c
+@@ -74,6 +74,7 @@ void fn(gaussian_blur)(int w, int h,
+                        uint8_t *dst, int dst_linesize,
+                        const uint8_t *src, int src_linesize, int src_stride)
+ {
++    int j;
+     pixel *srcp = (pixel *)src;
+     pixel *dstp = (pixel *)dst;
+
+@@ -81,12 +82,17 @@ void fn(gaussian_blur)(int w, int h,
+     src_linesize /= sizeof(pixel);
+     dst_linesize /= sizeof(pixel);
+
+-    memcpy(dstp, srcp, w*sizeof(pixel)); dstp += dst_linesize; srcp += src_linesize;
+-    memcpy(dstp, srcp, w*sizeof(pixel)); dstp += dst_linesize; srcp += src_linesize;
+-    for (int j = 2; j < h - 2; j++) {
+-        dstp[0] = srcp[(0)*src_stride];
+-        dstp[1] = srcp[(1)*src_stride];
+-        for (int i = 2; i < w - 2; i++) {
++    for (j = 0; j < FFMIN(h, 2); j++) {
++        memcpy(dstp, srcp, w*sizeof(pixel));
++        dstp += dst_linesize;
++        srcp += src_linesize;
++    }
++
++    for (; j < h - 2; j++) {
++        int i;
++        for (i = 0; i < FFMIN(w, 2); i++)
++            dstp[i] = srcp[i*src_stride];
++        for (; i < w - 2; i++) {
+             /* Gaussian mask of size 5x5 with sigma = 1.4 */
+             dstp[i] = ((srcp[-2*src_linesize + (i-2)*src_stride] + srcp[2*src_linesize + (i-2)*src_stride]) * 2
+                      + (srcp[-2*src_linesize + (i-1)*src_stride] + srcp[2*src_linesize + (i-1)*src_stride]) * 4
+@@ -106,12 +112,15 @@ void fn(gaussian_blur)(int w, int h,
+                      + srcp[(i+1)*src_stride] * 12
+                      + srcp[(i+2)*src_stride] *  5) / 159;
+         }
+-        dstp[w - 2] = srcp[(w - 2)*src_stride];
+-        dstp[w - 1] = srcp[(w - 1)*src_stride];
++        for (; i < w; i++)
++            dstp[i] = srcp[i*src_stride];
+
+         dstp += dst_linesize;
+         srcp += src_linesize;
+     }
+-    memcpy(dstp, srcp, w*sizeof(pixel)); dstp += dst_linesize; srcp += src_linesize;
+-    memcpy(dstp, srcp, w*sizeof(pixel));
++    for (; j < h; j++) {
++        memcpy(dstp, srcp, w*sizeof(pixel));
++        dstp += dst_linesize;
++        srcp += src_linesize;
++    }
+ }

--- a/debian/patches/CVE-2024-35365.patch
+++ b/debian/patches/CVE-2024-35365.patch
@@ -1,0 +1,54 @@
+From ced5c5fdb8634d39ca9472a2026b2d2fea16c4e5 Mon Sep 17 00:00:00 2001
+From: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+Date: Mon, 25 Mar 2024 16:54:25 +0100
+Subject: [PATCH] fftools/ffmpeg_mux_init: Fix double-free on error
+
+MATCH_PER_STREAM_OPT iterates over all options of a given
+OptionDef and tests whether they apply to the current stream;
+if so, they are set to ost->apad, otherwise, the code errors
+out. If no error happens, ost->apad is av_strdup'ed in order
+to take ownership of this pointer.
+
+But this means that setting it originally was premature,
+as it leads to double-frees when an error happens lateron.
+This can simply be reproduced with
+ffmpeg -filter_complex anullsrc  -apad bar -apad:n baz -f null -
+This is a regression since 83ace80bfd80fcdba2c65fa1d554923ea931d5bd.
+
+Fix this by using a temporary variable instead of directly
+setting ost->apad. Also only strdup the string if it actually
+is != NULL.
+
+Reviewed-by: Marth64 <marth64@proxyid.net>
+Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+---
+ fftools/ffmpeg_mux_init.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/fftools/ffmpeg_mux_init.c b/fftools/ffmpeg_mux_init.c
+index 818d76acda8c2..d3d7d022ff6f7 100644
+--- a/fftools/ffmpeg_mux_init.c
++++ b/fftools/ffmpeg_mux_init.c
+@@ -832,6 +832,7 @@ static int new_stream_audio(Muxer *mux, const OptionsContext *o,
+         int channels = 0;
+         char *layout = NULL;
+         char *sample_fmt = NULL;
++        const char *apad = NULL;
+
+         MATCH_PER_STREAM_OPT(audio_channels, i, channels, oc, st);
+         if (channels) {
+@@ -854,8 +855,12 @@ static int new_stream_audio(Muxer *mux, const OptionsContext *o,
+
+         MATCH_PER_STREAM_OPT(audio_sample_rate, i, audio_enc->sample_rate, oc, st);
+
+-        MATCH_PER_STREAM_OPT(apad, str, ost->apad, oc, st);
+-        ost->apad = av_strdup(ost->apad);
++        MATCH_PER_STREAM_OPT(apad, str, apad, oc, st);
++        if (apad) {
++            ost->apad = av_strdup(apad);
++            if (!ost->apad)
++                return AVERROR(ENOMEM);
++        }
+     }
+
+     return 0;

--- a/debian/patches/CVE-2024-36615.patch
+++ b/debian/patches/CVE-2024-36615.patch
@@ -1,0 +1,89 @@
+From 0ba058579f332b3060d8470a04ddd3fbf305be61 Mon Sep 17 00:00:00 2001
+From: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+Date: Fri, 12 Aug 2022 03:05:34 +0200
+Subject: [PATCH] avcodec/vp9: Fix race when attaching side-data for
+ show-existing frame
+
+When outputting a show-existing frame, the VP9 decoder simply
+created a reference to said frame and returned it immediately to
+the caller, without waiting for it to have finished decoding.
+In case of frame-threading it is possible for the frame to
+only be decoded while it was waiting to be output.
+This is normally benign.
+
+But there is one case where it is not: If the user wants
+video encoding parameters to be exported, said side data
+will only be attached to the src AVFrame at the end of
+decoding the frame that is actually being shown. Without
+synchronisation adding said side data in the decoder thread
+and the reads in av_frame_ref() in the output thread
+constitute a data race. This happens e.g. when using the
+venc_data_dump tool with vp90-2-10-show-existing-frame.webm
+from the FATE-suite.
+
+Fix this by actually waiting for the frame to be output.
+
+Signed-off-by: Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
+---
+ libavcodec/vp9.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
+index bd52478ce718a..e0bc313301eba 100644
+--- a/libavcodec/vp9.c
++++ b/libavcodec/vp9.c
+@@ -1569,6 +1569,8 @@ static int vp9_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+             av_log(avctx, AV_LOG_ERROR, "Requested reference %d not available\n", ref);
+             return AVERROR_INVALIDDATA;
+         }
++        ff_progress_frame_await(&s->s.refs[ref], INT_MAX);
++
+         if ((ret = av_frame_ref(frame, s->s.refs[ref].f)) < 0)
+             return ret;
+         frame->pts     = pkt->pts;
+@@ -1715,10 +1717,8 @@ static int vp9_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+ #endif
+         {
+             ret = decode_tiles(avctx, data, size);
+-            if (ret < 0) {
+-                ff_progress_frame_report(&s->s.frames[CUR_FRAME].tf, INT_MAX);
+-                return ret;
+-            }
++            if (ret < 0)
++                goto fail;
+         }
+
+         // Sum all counts fields into td[0].counts for tile threading
+@@ -1732,18 +1732,19 @@ static int vp9_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+             ff_thread_finish_setup(avctx);
+         }
+     } while (s->pass++ == 1);
+-    ff_progress_frame_report(&s->s.frames[CUR_FRAME].tf, INT_MAX);
+
+     if (s->td->error_info < 0) {
+         av_log(avctx, AV_LOG_ERROR, "Failed to decode tile data\n");
+         s->td->error_info = 0;
+-        return AVERROR_INVALIDDATA;
++        ret = AVERROR_INVALIDDATA;
++        goto fail;
+     }
+     if (avctx->export_side_data & AV_CODEC_EXPORT_DATA_VIDEO_ENC_PARAMS) {
+         ret = vp9_export_enc_params(s, &s->s.frames[CUR_FRAME]);
+         if (ret < 0)
+-            return ret;
++            goto fail;
+     }
++    ff_progress_frame_report(&s->s.frames[CUR_FRAME].tf, INT_MAX);
+
+ finish:
+     // ref frame setup
+@@ -1757,6 +1758,9 @@ static int vp9_decode_frame(AVCodecContext *avctx, AVFrame *frame,
+     }
+
+     return pkt->size;
++fail:
++    ff_progress_frame_report(&s->s.frames[CUR_FRAME].tf, INT_MAX);
++    return ret;
+ }
+
+ static void vp9_decode_flush(AVCodecContext *avctx)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,8 @@
 0002-avcodec-tests-rename-the-bundled-Mesa-AV1-vulkan-vid.patch
 0003-swscale-output-cve-2025-63757.patch
 0004-avcodec-jpeg2000dec-cve-2025-9951.patch
+CVE-2023-49501.patch
+CVE-2023-49528.patch
+CVE-2023-50009.patch
+CVE-2024-35365.patch
+CVE-2024-36615.patch


### PR DESCRIPTION
## Summary
This commit addresses multiple security vulnerabilities (CVE) in FFmpeg:

- **CVE-2023-49501**: Fixes buffer overflow in libavfilter/asrc_afirsrc:495:30 by allocating one additional byte in the buffer allocation
- **CVE-2023-49528**: Fixes buffer overflow in libavfilter/af_dialoguenhance:261:5 by using FFMIN to prevent overreads in memcpy operations
- **CVE-2023-50009**: Fixes heap-based buffer overflow in libavfilter/edge_template:116:5 by handling small inputs correctly in gaussian_blur() function
- **CVE-2024-35365**: Fixes double-free vulnerability in fftools/ffmpeg_mux_init by using a temporary variable for apad option handling
- **CVE-2024-36615**: Fixes race condition in VP9 decoder when attaching side-data for show-existing frame

All patches are derived from upstream FFmpeg commits and have been validated using quilt patch management system.

## Testing
- Patches verified with debian quilt system
- All patches applied successfully
- Generated patches follow Debian packaging standards

## Security Impact
These fixes address multiple high-severity security vulnerabilities that could allow:
- Remote code execution (buffer overflows)
- Denial of service
- Double-free exploits
- Race conditions in multi-threaded decoding

## References
- CVE-2023-49501: https://trac.ffmpeg.org/ticket/10686
- CVE-2023-49528: https://trac.ffmpeg.org/ticket/10691
- CVE-2023-50009: https://trac.ffmpeg.org/ticket/10699
- CVE-2024-35365: https://github.com/ffmpeg/ffmpeg/commit/ced5c5fdb8634d39ca9472a2026b2d2fea16c4e5
- CVE-2024-36615: https://github.com/ffmpeg/ffmpeg/commit/0ba058579f332b3060d8470a04ddd3fbf305be61