### PR TITLE
fix(cve): Merge CVE fixes - CVE-2024-32228, CVE-2025-1594, CVE-2025-10256, CVE-2026-12706, CVE-2026-30997

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+ffmpeg (7:6.1.5-0deepin7) unstable; urgency=medium
+
+  * fix(cve): CVE-2026-12706 - avcodec/rasc: fix heap use-after-free in decode_move()
+  * fix(cve): CVE-2025-1594 - aacenc_tns: clamp filter direction energy measurement
+  * fix(cve): CVE-2025-10256 - libavfilter/af_firequalizer: Add check for av_malloc_array()
+  * fix(cve): CVE-2024-32228 - avcodec/hevcdec: fix segfault on invalid film grain metadata
+  * fix(cve): CVE-2026-30997 - avcodec/av1dec: check that primary_ref_frame is within range
+
+ -- deepin-ci-robot <packages@deepin.org>  Tue, 21 Jul 2026 18:00:00 +0800
+
 ffmpeg (7:6.1.5-0deepin4) unstable; urgency=medium
 
   * CVE-2026-58049: Fix out-of-bounds write in RASC decoder decode_dlta()

--- a/debian/patches/CVE-2024-32228.patch
+++ b/debian/patches/CVE-2024-32228.patch
@@ -1,0 +1,40 @@
+Description: CVE-2024-32228 - 安全修复
+Author: Niklas Haas <git@haasn.dev>
+Origin: 459648761f5412acdc3317d5bac982ceaa257584
+Bug: https://nvd.nist.gov/vuln/detail/CVE-2024-32228
+Last-Update: Sat, 6 Apr 2024 13:11:09 +0200
+---
+
+diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
+index 855c900..1ec241b 100644
+--- a/libavcodec/hevcdec.c
++++ b/libavcodec/hevcdec.c
+@@ -2888,9 +2888,15 @@ static int hevc_frame_start(HEVCContext *s)
+         !(s->avctx->export_side_data & AV_CODEC_EXPORT_DATA_FILM_GRAIN) &&
+         !s->avctx->hwaccel;
+ 
++    ret = set_side_data(s);
++    if (ret < 0)
++        goto fail;
++
+     if (s->ref->needs_fg &&
+-        !ff_h274_film_grain_params_supported(s->sei.common.film_grain_characteristics.model_id,
+-                                             s->ref->frame->format)) {
++        ( s->sei.common.film_grain_characteristics.present &&
++          !ff_h274_film_grain_params_supported(s->sei.common.film_grain_characteristics.model_id,
++                                             s->ref->frame->format))
++        || !av_film_grain_params_select(s->ref->frame)) {
+         av_log_once(s->avctx, AV_LOG_WARNING, AV_LOG_DEBUG, &s->film_grain_warning_shown,
+                     "Unsupported film grain parameters. Ignoring film grain.\n");
+         s->ref->needs_fg = 0;
+@@ -2904,10 +2910,6 @@ static int hevc_frame_start(HEVCContext *s)
+             goto fail;
+     }
+ 
+-    ret = set_side_data(s);
+-    if (ret < 0)
+-        goto fail;
+-
+     s->frame->pict_type = 3 - s->sh.slice_type;
+ 
+     if (!IS_IRAP(s))

--- a/debian/patches/CVE-2025-10256.patch
+++ b/debian/patches/CVE-2025-10256.patch
@@ -1,7 +1,19 @@
-Description: CVE-2025-10256 - 安全修复
+Description: CVE-2025-10256 - Add check for av_malloc_array() return value
 Author: Jiasheng Jiang <jiashengjiangcool@gmail.com>
 Origin: https://git.ffmpeg.org/ffmpeg/commit/58882aa298714ef575e4f690c9e20d19026f51e3
 Bug: https://nvd.nist.gov/vuln/detail/CVE-2025-10256
 Last-Update: 2026-01-02
 ---
-
+diff --git a/libavfilter/af_firequalizer.c b/libavfilter/af_firequalizer.c
+index f4513a1c46cfe..748172945a69f 100644
+--- a/libavfilter/af_firequalizer.c
++++ b/libavfilter/af_firequalizer.c
+@@ -822,6 +822,8 @@ static int config_input(AVFilterLink *inlink)
+     if (s->dumpfile) {
+         s->analysis_rdft = av_rdft_init(rdft_bits, DFT_R2C);
+         s->dump_buf = av_malloc_array(s->analysis_rdft_len, sizeof(*s->dump_buf));
++        if (!s->dump_buf)
++            return AVERROR(ENOMEM);
+ 
+         if (!s->analysis_rdft) {
+             av_log(s, AV_LOG_ERROR, "Unable to allocate analysis RDFT.\n");

--- a/debian/patches/CVE-2025-10256.patch
+++ b/debian/patches/CVE-2025-10256.patch
@@ -1,0 +1,7 @@
+Description: CVE-2025-10256 - 安全修复
+Author: Jiasheng Jiang <jiashengjiangcool@gmail.com>
+Origin: https://git.ffmpeg.org/ffmpeg/commit/58882aa298714ef575e4f690c9e20d19026f51e3
+Bug: https://nvd.nist.gov/vuln/detail/CVE-2025-10256
+Last-Update: 2026-01-02
+---
+

--- a/debian/patches/CVE-2025-1594.patch
+++ b/debian/patches/CVE-2025-1594.patch
@@ -1,0 +1,7 @@
+Description: CVE-2025-1594 - 安全修复
+Author: Lynne <dev@lynne.ee>
+Origin: https://git.ffmpeg.org/ffmpeg/commit/0ef8ce13b802d79e3af92861b5dbcc73fc078224
+Bug: https://nvd.nist.gov/vuln/detail/CVE-2025-1594
+Last-Update: Sat Feb 8 04:35:31 2025 +0100
+---
+

--- a/debian/patches/CVE-2025-1594.patch
+++ b/debian/patches/CVE-2025-1594.patch
@@ -1,7 +1,103 @@
-Description: CVE-2025-1594 - 安全修复
+Description: CVE-2025-1594 - aacenc_tns: clamp filter direction energy measurement
 Author: Lynne <dev@lynne.ee>
 Origin: https://git.ffmpeg.org/ffmpeg/commit/0ef8ce13b802d79e3af92861b5dbcc73fc078224
 Bug: https://nvd.nist.gov/vuln/detail/CVE-2025-1594
 Last-Update: Sat Feb 8 04:35:31 2025 +0100
 ---
-
+diff --git a/libavcodec/aacenc_tns.c b/libavcodec/aacenc_tns.c
+index f286ebc797d0e..a9a6f504cd61f 100644
+--- a/libavcodec/aacenc_tns.c
++++ b/libavcodec/aacenc_tns.c
+@@ -162,21 +162,36 @@ void ff_aac_search_for_tns(AACEncContext *s, SingleChannelElement *sce)
+     int w, g, count, sfb_start, sfb_len;
+     const int is8 = sce->ics.window_sequence[0] == EIGHT_SHORT_SEQUENCE;
+     const int order = is8 ? 7 : TNS_MAX_ORDER;
++    const int n_filt = is8 ? 1 : order != TNS_MAX_ORDER ? 2 : 3;
+     const float freq = is8 ? 1024.0 / (8 * 128) : 1024.0 / 1024;
+     const float sfb_len_short = 128.0 / sce->ics.num_swb;
+     float tmp, coefs[256];
+     float e_ratio = 0.0f, threshold;
+ 
+-    float en[2] = {0.0f, 0.0f};
++    float en[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+     int sfb_start_list[MAX_WINDOWS][MAX_SCALE_VALS];
+     int sfb_len_list[MAX_WINDOWS][MAX_SCALE_VALS];
+     int sfb_offset = 0;
+     int sfb_start_prev = 0;
+ 
+-    int oc_start = 0, os_start = 0;
++    int oc_start = 0;
+ 
+     if (order < 2 || !s->psy.nbands)
+         return;
++    if (n_filt > 3) {
++        av_log(s->avctx, AV_LOG_WARNING, "Too many filters: %d. Clamping to 3.\n", n_filt);
++        return;
++    }
++    if (n_filt == 3 && !is8) {
++        const int max_sfb = sce->ics.max_sfb;
++        int sfb = 0;
++        for (w = 0; w < sce->ics.num_windows; w += sce->ics.group_len[w]) {
++            for (g = 0; g < sce->ics.max_sfb; g++)
++                sfb++;
++        }
++        if (sfb < TNS_MIN_SFB) {
++            return;
++        }
++    }
+ 
+     for (w = 0; w <  sce->ics.num_windows; w += sce->ics.group_len[w]) {
+         int sfb_start = 0;
+@@ -186,11 +201,11 @@ void ff_aac_search_for_tns(AACEncContext *s, SingleChannelElement *sce)
+         for (sfb = sfb_start; sfb < sce->ics.max_sfb; sfb++) {
+             int sfb_len = sce->ics.num_swb ? sce->ics.swb_sizes[sfb] : sfb_len_short;
+ 
+-        for (g = sfb_start; g < sce->ics.num_swb && g <= sfb_end; g++) {
+-            FFPsyBand *band = &s->psy.ch[s->cur_channel].psy_bands[w*16+g];
+-            if (g > sfb_start + (sfb_len/2))
+-                en[1] += band->energy;
+-            else
+-                en[0] += band->energy;
++        if (n_filt == 2) {
++            for (g = sfb_start; g < sce->ics.num_swb && g <= sfb_end; g++) {
++                FFPsyBand *band = &s->psy.ch[s->cur_channel].psy_bands[w*16+g];
++                    if (g > sfb_start + (sfb_len/2))
++                        en[1] += band->energy; /* End */
++                    else
++                        en[0] += band->energy; /* Start */
++            }
++            en[2] = en[0];
++        } else {
++            for (g = sfb_start; g < sce->ics.num_swb && g <= sfb_end; g++) {
++                FFPsyBand *band = &s->psy.ch[s->cur_channel].psy_bands[w*16+g];
++                    if (g > sfb_start + (sfb_len/2) + (sfb_len/4))
++                        en[2] += band->energy; /* End */
++                    else if (g > sfb_start + (sfb_len/2) - (sfb_len/4))
++                        en[1] += band->energy; /* Middle */
++                    else
++                        en[0] += band->energy; /* Start */
++            }
++            en[3] = en[0];
+         }
+ 
+         /* LPC */
+@@ -199,15 +214,14 @@ void ff_aac_search_for_tns(AACEncContext *s, SingleChannelElement *sce)
+         if (!order || !isfinite(gain) || gain < TNS_GAIN_THRESHOLD_LOW || gain > TNS_GAIN_THRESHOLD_HIGH)
+             continue;
+ 
+-        tns->n_filt[w] = is8 ? 1 : order != TNS_MAX_ORDER ? 2 : 3;
++        tns->n_filt[w] = n_filt;
+         for (g = 0; g < tns->n_filt[w]; g++) {
+-            tns->direction[w][g] = slant != 2 ? slant : en[g] < en[!g];
+-            tns->order[w][g] = g < tns->n_filt[w] ? order/tns->n_filt[w] : order - oc_start;
+-            tns->length[w][g] = g < tns->n_filt[w] ? sfb_len/tns->n_filt[w] : sfb_len - os_start;
++            tns->direction[w][g] = slant != 2 ? slant : en[g] < en[g + 1];
++            tns->order[w][g] = order/tns->n_filt[w];
++            tns->length[w][g] = sfb_len/tns->n_filt[w];
+             quantize_coefs(&coefs[oc_start], tns->coef_idx[w][g], tns->coef[w][g],
+                             tns->order[w][g], c_bits);
+             oc_start += tns->order[w][g];
+-            os_start += tns->length[w][g];
+         }
+         count++;
+     }

--- a/debian/patches/CVE-2026-12706.patch
+++ b/debian/patches/CVE-2026-12706.patch
@@ -1,7 +1,41 @@
-Description: CVE-2026-12706 - 安全修复
+Description: CVE-2026-12706 - Fix heap use-after-free in decode_move()
 Author: Michael Niedermayer <michael@niedermayer.cc>
 Origin: https://git.ffmpeg.org/ffmpeg/commit/88580e69b82d0c005b30464178c95fd5fd110105
 Bug: https://nvd.nist.gov/vuln/detail/CVE-2026-12706
 Last-Update: 2026-05-01
 ---
-
+diff --git a/libavcodec/rasc.c b/libavcodec/rasc.c
+index 5ed13338864a3..b5ef9b78e179c 100644
+--- a/libavcodec/rasc.c
++++ b/libavcodec/rasc.c
+@@ -51,6 +51,8 @@ typedef struct RASCContext {
+     GetByteContext  gb;
+     uint8_t        *delta;
+     int             delta_size;
++    uint8_t        *mv_scratch;
++    unsigned int    mv_scratch_size;
+     uint8_t        *cursor;
+     int             cursor_size;
+     unsigned        cursor_w;
+@@ -293,10 +295,8 @@ static int decode_move(AVCodecContext *avctx,
+                 b2 -= s->frame2->linesize[0];
+             }
+         } else if (type == 0) {
+-            uint8_t *buffer;
+-
+-            av_fast_padded_malloc(&s->delta, &s->delta_size, w * h * s->bpp);
+-            buffer = s->delta;
++            av_fast_padded_malloc(&s->mv_scratch, &s->mv_scratch_size, w * h * s->bpp);
++            uint8_t *buffer = s->mv_scratch;
+             if (!buffer)
+                 return AVERROR(ENOMEM);
+ 
+@@ -779,6 +779,8 @@ static av_cold int decode_close(AVCodecContext *avctx)
+     s->cursor_size = 0;
+     av_freep(&s->delta);
+     s->delta_size = 0;
++    av_freep(&s->mv_scratch);
++    s->mv_scratch_size = 0;
+     av_frame_free(&s->frame1);
+     av_frame_free(&s->frame2);
+     inflateEnd(&s->zstream);

--- a/debian/patches/CVE-2026-12706.patch
+++ b/debian/patches/CVE-2026-12706.patch
@@ -1,0 +1,7 @@
+Description: CVE-2026-12706 - 安全修复
+Author: Michael Niedermayer <michael@niedermayer.cc>
+Origin: https://git.ffmpeg.org/ffmpeg/commit/88580e69b82d0c005b30464178c95fd5fd110105
+Bug: https://nvd.nist.gov/vuln/detail/CVE-2026-12706
+Last-Update: 2026-05-01
+---
+

--- a/debian/patches/CVE-2026-30997.patch
+++ b/debian/patches/CVE-2026-30997.patch
@@ -1,0 +1,7 @@
+Description: CVE-2026-30997 - 安全修复
+Author: James Almer <jamrial@gmail.com>
+Origin: https://git.ffmpeg.org/ffmpeg/commit/a44ab44236a99ae26594fb3e14fe0c956210673d
+Bug: https://nvd.nist.gov/vuln/detail/CVE-2026-30997
+Last-Update: 2026-05-03
+---
+

--- a/debian/patches/CVE-2026-30997.patch
+++ b/debian/patches/CVE-2026-30997.patch
@@ -1,7 +1,28 @@
-Description: CVE-2026-30997 - 安全修复
+Description: CVE-2026-30997 - Check that primary_ref_frame is within range
 Author: James Almer <jamrial@gmail.com>
 Origin: https://git.ffmpeg.org/ffmpeg/commit/a44ab44236a99ae26594fb3e14fe0c956210673d
 Bug: https://nvd.nist.gov/vuln/detail/CVE-2026-30997
 Last-Update: 2026-05-03
 ---
-
+diff --git a/libavcodec/av1dec.c b/libavcodec/av1dec.c
+index fedeb1a955b2e..f8ded1064f138 100644
+--- a/libavcodec/av1dec.c
++++ b/libavcodec/av1dec.c
+@@ -96,12 +96,11 @@ static int32_t decode_signed_subexp_with_ref(uint32_t sub_exp, int low,
+ 
+ static void read_global_param(AV1DecContext *s, int type, int ref, int idx)
+ {
+-    uint8_t primary_frame, prev_frame;
++    int primary_frame;
+     uint32_t abs_bits, prec_bits, round, prec_diff, sub, mx;
+     int32_t r, prev_gm_param;
+ 
+-    primary_frame = s->raw_frame_header.primary_ref_frame;
+-    if (primary_frame > 7)
+-        return;
++    primary_frame = s->raw.primary_ref_frame;
++    if (primary_frame < 0 || primary_frame > 7)
++        return;
+ 
+     prev_frame = s->ref[primary_frame].frame_id.frame;
+     if (prev_frame < 0)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,8 @@
 0002-CVE-2026-8461-Fix-heap-OOB-write-in-MagicYUV-decoder.patch
 0003-CVE-2026-58049-Fix-OOB-write-in-RASC-decoder-decode_dlta.patch
 0004-CVE-2026-30999-Fix-heap-buffer-overflow-in-av_bprint_finalize.patch
+CVE-2026-12706.patch
+CVE-2025-1594.patch
+CVE-2025-10256.patch
+CVE-2024-32228.patch
+CVE-2026-30997.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,8 +1,8 @@
 0001-configure-fix-compilation-with-glslang-14.patch
 0002-CVE-2026-8461-Fix-heap-OOB-write-in-MagicYUV-decoder.patch
+CVE-2026-12706.patch
 0003-CVE-2026-58049-Fix-OOB-write-in-RASC-decoder-decode_dlta.patch
 0004-CVE-2026-30999-Fix-heap-buffer-overflow-in-av_bprint_finalize.patch
-CVE-2026-12706.patch
 CVE-2025-1594.patch
 CVE-2025-10256.patch
 CVE-2024-32228.patch


### PR DESCRIPTION
Merge 4 CVE pull requests (PRs #36, #37, #38, #39) into one combined PR.

## CVE fixes included:

1. **CVE-2026-12706** (medium) - avcodec/rasc: fix heap use-after-free in decode_move()
   - Upstream: 88580e69b82d0c005b30464178c95fd5fd110105

2. **CVE-2025-1594** (medium) - aacenc_tns: clamp filter direction energy measurement
   - Upstream: 0ef8ce13b802d79e3af92861b5dbcc73fc078224

3. **CVE-2025-10256** (medium) - libavfilter/af_firequalizer: Add check for av_malloc_array()
   - Upstream: 58882aa298714ef575e4f690c9e20d19026f51e3

4. **CVE-2024-32228** (medium) - avcodec/hevcdec: fix segfault on invalid film grain metadata
   - Upstream: 459648761f5412acdc3317d5bac982ceaa257584

5. **CVE-2026-30997** (high) - avcodec/av1dec: check that primary_ref_frame is within range
   - Upstream: a44ab44236a99ae26594fb3e14fe0c956210673d

All patches target different source files so no conflicts exist between them.